### PR TITLE
fix nil consumption from singleConsumer

### DIFF
--- a/pool/config.go
+++ b/pool/config.go
@@ -1,6 +1,10 @@
 package pool
 
-import "time"
+import (
+	"math"
+	"runtime"
+	"time"
+)
 
 // Config defines params for Dispatcher.
 type Config struct {
@@ -64,7 +68,8 @@ func NewConfig(opts ...Opt) Config {
 	}
 
 	if conf.numConsumers == 0 {
-		conf.numConsumers = 2
+		numConsumers := math.Max(float64(runtime.NumCPU()-2), 2)
+		conf.numConsumers = int(numConsumers)
 	}
 
 	return conf

--- a/pool/consumer.go
+++ b/pool/consumer.go
@@ -143,7 +143,10 @@ type singleConsumer[E any] struct {
 func (c *singleConsumer[E]) Start() {
 	for {
 		select {
-		case e := <-c.queue.DequeueBlocking():
+		case e, ok := <-c.queue.DequeueBlocking():
+			if !ok {
+				continue
+			}
 			err := c.worker(e)
 			if err != nil {
 				// TODO(jamesjarvis): Do something with this error I guess?


### PR DESCRIPTION
- set default consumers to NUM_CPU-2
- may send empty objects forward with the singleConsumer
